### PR TITLE
fix: update language in popup settings, add a new selector for submit button

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -23,6 +23,7 @@ async function main() {
     mainContentContainer.insertAdjacentElement("afterend", reactRoot);
 
     const submissionButtonSelectors = [
+        "#qd-content > div > div> div:nth-child(3) > div > div > div > div > div > div:nth-last-child(1) > button:nth-last-child(1)",
         "#__next > div > div > div > div > div > div:nth-child(3) > div > div:nth-child(3) > div > div > div > div > div > div:nth-last-child(1) > button:nth-last-child(1)",
         "#__next > div > div > div > div > div > div:nth-child(3) > div > div:nth-child(3) > div > div > div:nth-child(3) > div > div > div:nth-child(3) > button:nth-last-child(1)",
     ];

--- a/extension/src/public/manifest.json
+++ b/extension/src/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "LeetRooms",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Multiplayer rooms for LeetCode.",
     "homepage_url": "https://leetrooms.com",
     "permissions": ["activeTab", "storage"],

--- a/extension/src/public/popup.html
+++ b/extension/src/public/popup.html
@@ -30,7 +30,7 @@
                             />
                             <span class="slider round"></span>
                         </label>
-                        <span>Enable LeetRooms</span>
+                        <span>Show/Hide LeetRooms Panel</span>
                     </div>
                     <div id="leetrooms-width-container" class="flex-row">
                         <input


### PR DESCRIPTION
Previously the popup HTML had a toggle that said "Enable LeetRooms" and this gave the false impression that it would kick you out of the room if you toggled it off. In reality, all it does is hide/show the LeetRooms element. This PR updates the language to "Show/Hide LeetRooms panel" to avoid that confusion.

This PR also adds a new selector for the submission button because some users reported that their submissions weren't showing up in the chat and that the existing selectors returned null.