### PR TITLE
fix: prevent duplicate submissions

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,6 +1,7 @@
 const APP_URL = import.meta.env.VITE_APP_URL;
 
 async function main() {
+    let previousSubmissionId = "";
     const reactRoot = document.createElement("iframe");
 
     reactRoot.src = APP_URL;
@@ -100,6 +101,10 @@ async function main() {
     });
 
     chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        if (previousSubmissionId == message.submissionId) {
+            return;
+        }
+        previousSubmissionId = message.submissionId;
         handleClickSubmitCodeButton(message.submissionId);
     });
 }

--- a/extension/src/public/background.js
+++ b/extension/src/public/background.js
@@ -1,12 +1,7 @@
-const SUBMISSION_DELAY = 1000;
-let lastSentTime = 0;
-let sendInProgress = false;
-
 chrome.webRequest.onBeforeRequest.addListener(
     (details) => {
         let submissionId = parseSubmissionId(details.url);
-        const currentTime = Date.now();
-        if (submissionId && currentTime - lastSentTime >= SUBMISSION_DELAY) {
+        if (submissionId) {
             sendMessage(submissionId);
         }
     },
@@ -30,20 +25,11 @@ function parseSubmissionId(url) {
 }
 
 function sendMessage(submissionId) {
-    if (!sendInProgress) {
-        sendInProgress = true;
-        lastSentTime = Date.now();
-
-        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-            if (tabs[0]) {
-                chrome.tabs.sendMessage(tabs[0].id, {
-                    submissionId: submissionId,
-                });
-            }
-        });
-
-        setTimeout(() => {
-            sendInProgress = false;
-        }, SUBMISSION_DELAY);
-    }
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (tabs[0]) {
+            chrome.tabs.sendMessage(tabs[0].id, {
+                submissionId: submissionId,
+            });
+        }
+    });
 }

--- a/extension/src/public/manifest.json
+++ b/extension/src/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "LeetRooms",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Multiplayer rooms for LeetCode.",
     "homepage_url": "https://leetrooms.com",
     "permissions": ["activeTab", "storage", "webRequest"],


### PR DESCRIPTION
Some users would report seeing their submission event appearing multiple times in the chat - especially when the judge takes a long time to determine if a submission is AC.