### PR TITLE
fix: delay join room message

### DIFF
--- a/extension/src/components/Room.tsx
+++ b/extension/src/components/Room.tsx
@@ -51,15 +51,7 @@ export default function Room({
     const isLoadingGlobal = useIsMutating();
     let inputRef = useRef<HTMLInputElement>(null);
     let messagesRef = useRef<HTMLUListElement>(null);
-    let [messages, setMessages] = useState<MessageInterface[]>([
-        {
-            timestamp: Date.now(),
-            username: username,
-            body: "joined the room!",
-            chatEvent: ChatEvent.Join,
-            color: userColor,
-        },
-    ]);
+    let [messages, setMessages] = useState<MessageInterface[]>([]);
     let [hasClickedCopyIcon, setHasClickedCopyIcon] = useState(false);
     let socketRef = useRef<Socket | null>(null);
     let previousSubmissionUrl = useRef<string | null>(null);

--- a/server/src/api/rooms/rooms.handler.ts
+++ b/server/src/api/rooms/rooms.handler.ts
@@ -389,7 +389,10 @@ function sendJoinRoomMessage(username: string, room: RoomSession) {
         chatEvent: ChatEvent.Join,
         color: room.userColor,
     };
-    io.to(room.roomId).emit("chat-message", newJoinMessage);
+    // Delay by 500ms so that the user can see the join room message when re-entering
+    setTimeout(() => {
+        io.to(room.roomId).emit("chat-message", newJoinMessage);
+    }, 500);
 }
 
 function getNumberOfQuestionsPerDifficulty(


### PR DESCRIPTION
Delay sending the join room message by 500ms so that you can see your own "joined the room" message when re-entering. Some users would re-enter a room and not see the message because the message was sent before the client's socket.io connection was established. They mistakenly thought they were not in the room or that there was a bug.

This isn't a perfect solution because users with slow connections may require more than 500ms.