### PR TITLE
fix: secure docker ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
   redis:
     image: redis
     command: >
@@ -17,7 +17,7 @@ services:
     volumes:
       - redis_data:/data
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
By default, docker bypasses ufw firewall and any ports you expose in docker-compose are exposed to the outside world. There are many articles about how this has caused vulnerabilities and hacks in the past:
- https://blog.newsblur.com/2021/06/28/story-of-a-hacking/
- https://geoff.tuxpup.com/posts/psa_docker_edits_firewall_rules/
- https://github.com/moby/moby/issues/4737

This PR specifies the IP address (127.0.0.1) on which Docker should listen for connections destined to this container. This way the PostgreSQL service and Redis service will only be accessible from the local machine itself.

You can check if the port is open to the world using a website like this: https://www.yougetsignal.com/tools/open-ports/