### PR TITLE
feat: add question selection

### DIFF
--- a/extension/src/types/RoomSettings.ts
+++ b/extension/src/types/RoomSettings.ts
@@ -1,3 +1,5 @@
+import { QuestionInterface } from "./Question";
+
 export interface RoomSettings {
     questionFilter: QuestionFilter;
     duration?: number | null;
@@ -13,10 +15,12 @@ export interface RoomDifficulty {
 export interface QuestionFilter {
     kind: QuestionFilterKind;
     selections: string[];
+    questions?: QuestionInterface[];
 }
 
 export enum QuestionFilterKind {
     Topics = "topics",
+    Questions = "questions",
 }
 
 export const topics = [

--- a/server/src/api/app.ts
+++ b/server/src/api/app.ts
@@ -19,6 +19,7 @@ import http from "http";
 import { Server } from "socket.io";
 import { errorHandler, ensureAuthenticated } from "./middleware";
 import roomsRoute from "../api/rooms/rooms.route";
+import questionRoute from "../api/questions/question.router";
 import submissionsRoute from "../api/submissions/submissions.route";
 import authRoute from "../api/auth/auth.route";
 import session, { Session } from "express-session";
@@ -294,6 +295,7 @@ app.use(httplog);
 app.use("/auth", authRoute);
 app.use("/submissions", ensureAuthenticated, submissionsRoute);
 app.use("/rooms", ensureAuthenticated, roomsRoute);
+app.use("/questions", ensureAuthenticated, questionRoute);
 app.use(errorHandler);
 
 declare module "http" {

--- a/server/src/api/questions/question.router.ts
+++ b/server/src/api/questions/question.router.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { getQuestions, getQuestion } from "./questions.handler";
+// import * as RoomsHandler from "./rooms.handler";
+
+const router = Router();
+
+router.get("/", getQuestions);
+router.get("/search/:searchTerm", getQuestion);
+
+export default router;

--- a/server/src/api/questions/questions.handler.ts
+++ b/server/src/api/questions/questions.handler.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from "express";
+import prisma from "../../index";
+import { Question } from "@prisma/client";
+
+// get 20 questions randomly to search
+export async function getQuestions(_: Request, res: Response<any[]>) {
+    const questions = await prisma.$queryRaw<Question[]>`
+    SELECT *
+    FROM Questions
+    ORDER BY random()
+    LIMIT 20;`;
+
+    res.json(questions);
+}
+
+// search a specific question
+export async function getQuestion(
+    req: Request,
+    res: Response<any[]>,
+    next: NextFunction
+) {
+    const searchTerm = req.params.searchTerm ?? "";
+
+    if (!searchTerm) return;
+
+    try {
+        const results = await prisma.question.findMany({
+            where: {
+                title: {
+                    contains: searchTerm,
+                    mode: "insensitive",
+                },
+            },
+            take: 5,
+        });
+
+        res.json(results);
+    } catch (error) {
+        next(error);
+    }
+}

--- a/server/src/types/RoomSettings.ts
+++ b/server/src/types/RoomSettings.ts
@@ -23,6 +23,7 @@ export interface QuestionFilter {
 
 export enum QuestionFilterKind {
     Topics = "topics",
+    Questions = "questions",
 }
 
 export const topics = [


### PR DESCRIPTION
### Server changes:
* Added `Questions` to QuestionFilterKind, if the `filterKind` is `Questions`, the
`selections` will be an array of title-slug. First we need to find the questions
by title slug, the rest are remaining the same, basically a copy and paste from the
exisiting "Topics" logic, potentially can be refactored.

* Added question router and two endpoints, one for search a specific question by
search term, the other one will randomly return 20 questions for the user to
pick.

### Client (extension) changes:
* Added a new Tab called Questions, added search functionality which is server
side search, each time the server will return the most relevant 5 results.

* If the user chooses Questions over Topics, then the question title slug will be
saved into `RoomSetting.questionFilter.selections`.

* Added questions type to QuestionFilter in order to display the questions again
when setting modal is reopened.

* The user can max select 4 questions, which is the same as current behaviour.