### PR TITLE
fix(submissions.handler.ts): Calculate Time Difference

### DIFF
--- a/server/src/api/submissions/submissions.handler.ts
+++ b/server/src/api/submissions/submissions.handler.ts
@@ -142,16 +142,12 @@ function sendCompletedRoomMessage(
     io.to(room.roomId).emit("chat-message", completedRoomMessage);
 }
 
-function calculateTimeDifference(playerEnteredAt: Date, submittedAt: Date) {
+function calculateTimeDifference(playerEnteredAt: string | Date, submittedAt: string | Date) {
+    const normalizedPlayerEnteredAt = typeof playerEnteredAt === 'string' ? playerEnteredAt.replace(/Z?$/, 'Z') : playerEnteredAt;
+    const normalizedSubmittedAt = typeof submittedAt === 'string' ? submittedAt.replace(/Z?$/, 'Z') : submittedAt;
+    
     const dateConvertedSubmissionTime = new Date(submittedAt);
-
     let dateConvertedPlayerEnteredAt = new Date(playerEnteredAt);
-    const userTimezoneOffset =
-        dateConvertedPlayerEnteredAt.getTimezoneOffset() * 60000;
-    dateConvertedPlayerEnteredAt = new Date(
-        dateConvertedPlayerEnteredAt.getTime() +
-            userTimezoneOffset * Math.sign(userTimezoneOffset)
-    );
 
     const timeDifference =
         dateConvertedSubmissionTime.getTime() -


### PR DESCRIPTION
Adding Z to a GMT timezone datetime string will automatically make it convert correctly. There's no need to do weird timezone adjustments this way.
Fixes #53 