### PR TITLE
feat: add toggle to completely hide panel, show version in extension popup

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -79,6 +79,20 @@ async function main() {
         }
     }
 
+    function showPanel() {
+        chrome.storage.local.set({ shouldShowPanel: true });
+        setToggleState(true);
+        reactRoot.style.display = "block";
+        handlebar.style.display = "flex";
+    }
+
+    function hidePanel() {
+        chrome.storage.local.set({ shouldShowPanel: false });
+        setToggleState(false);
+        reactRoot.style.display = "none";
+        handlebar.style.display = "none";
+    }
+
     handlebar.addEventListener("dblclick", () => {
         if (isOpen) {
             setToggleState(false);
@@ -161,6 +175,14 @@ async function main() {
     window.addEventListener("mousemove", throttle(updateWidth, 16));
     window.addEventListener("mouseup", stopResizing);
 
+    chrome.storage.local.get("shouldShowPanel", (result) => {
+        const shouldShowPanel = result.shouldShowPanel ?? true;
+        if (shouldShowPanel) {
+            showPanel();
+        } else {
+            hidePanel();
+        }
+    });
     chrome.storage.local.get("leetroomsToggleState", (result) => {
         const toggleState = result.leetroomsToggleState ?? true;
         if (toggleState) {
@@ -257,7 +279,9 @@ async function main() {
         const startTime = Date.now();
         const timeout = 20_000;
         submissionButtonTimer = setInterval(() => {
-            const element = document.querySelector("[data-e2e-locator='submission-result']");
+            const element = document.querySelector(
+                "[data-e2e-locator='submission-result']"
+            );
             if (element?.innerHTML === "Accepted") {
                 clearInterval(submissionButtonTimer);
                 if (!reactRoot.contentWindow || !currentQuestionTitleSlug) {
@@ -281,6 +305,13 @@ async function main() {
 
     chrome.storage.onChanged.addListener((changes, namespace) => {
         for (let [key, { oldValue, newValue }] of Object.entries(changes)) {
+            if (key == "shouldShowPanel") {
+                if (newValue == true) {
+                    showPanel();
+                } else {
+                    hidePanel();
+                }
+            }
             if (key == "leetroomsToggleState") {
                 if (newValue == true) {
                     setToggleState(true);

--- a/extension/src/public/popup.css
+++ b/extension/src/public/popup.css
@@ -1,8 +1,10 @@
 body {
     width: 300px;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding: 0.5rem;
+}
+
+h2 {
+    margin: 0;
 }
 
 .flex-col {
@@ -21,12 +23,31 @@ body {
     gap: 0.5rem;
 }
 
+.flex-col-root {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.flex-col-footer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+}
+
 .flex-row {
     display: flex;
     align-items: center;
     justify-content: center;
     flex-direction: row;
     gap: 0.5rem;
+}
+
+#leetrooms-instructions {
+    gap: 0.75rem;
 }
 
 #leetrooms-instructions-text {
@@ -39,19 +60,12 @@ body {
     padding: 0.8rem;
     border-radius: 0.5rem;
     font-size: 0.9rem;
-    margin-top: 1rem;
     cursor: pointer;
-}
-
-#leetrooms-width-container {
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
 }
 
 #github-link {
     font-size: 0.8rem;
     color: blue;
-    margin-top: 1rem;
     cursor: pointer;
 }
 
@@ -106,4 +120,9 @@ input:checked + .slider:before {
 
 .slider.round:before {
     border-radius: 50%;
+}
+
+#leetrooms-icon {
+    width: 1.75rem;
+    height: auto;
 }

--- a/extension/src/public/popup.html
+++ b/extension/src/public/popup.html
@@ -9,9 +9,16 @@
         <script defer src="popup.js"></script>
     </head>
     <body>
-        <div class="flex-col">
-            <h2>LeetRooms</h2>
-            <div id="leetrooms-instructions">
+        <div id="root" class="flex-col-root">
+            <div class="flex-row">
+                <img
+                    id="leetrooms-icon"
+                    src="icons/128.png"
+                    alt="LeetRooms icon"
+                />
+                <h2>LeetRooms</h2>
+            </div>
+            <div id="leetrooms-instructions" class="flex-col">
                 <div id="leetrooms-instructions-text">
                     To use LeetRooms, go to any LeetCode problem and refresh the
                     page. You must be using the new LeetCode UI. You should see
@@ -42,7 +49,10 @@
                     </div>
                 </div>
             </div>
-            <div id="github-link">GitHub</div>
+            <div class="flex-col-footer">
+                <div id="github-link">GitHub</div>
+                <div id="version"></div>
+            </div>
         </div>
     </body>
 </html>

--- a/extension/src/public/popup.html
+++ b/extension/src/public/popup.html
@@ -22,12 +22,24 @@
                 </div>
             </div>
             <div id="leetrooms-settings">
-                <div class="flex-row">
-                    <label class="switch">
-                        <input id="toggle-leetrooms-darkmode" type="checkbox" />
-                        <span class="slider round"></span>
-                    </label>
-                    <span>Dark Mode</span>
+                <div class="flex-col-left">
+                    <div class="flex-row">
+                        <label class="switch">
+                            <input id="show-hide-leetrooms" type="checkbox" />
+                            <span class="slider round"></span>
+                        </label>
+                        <span>Show LeetRooms Panel</span>
+                    </div>
+                    <div class="flex-row">
+                        <label class="switch">
+                            <input
+                                id="toggle-leetrooms-darkmode"
+                                type="checkbox"
+                            />
+                            <span class="slider round"></span>
+                        </label>
+                        <span>Dark Mode</span>
+                    </div>
                 </div>
             </div>
             <div id="github-link">GitHub</div>

--- a/extension/src/public/popup.js
+++ b/extension/src/public/popup.js
@@ -1,3 +1,15 @@
+document.addEventListener("DOMContentLoaded", () => {
+    fetch("./manifest.json")
+        .then((response) => response.json())
+        .then((data) => {
+            const version = data.version;
+            document.querySelector(
+                "#version"
+            ).textContent = `Version ${version}`;
+        })
+        .catch((error) => console.error("Error loading the version:", error));
+});
+
 const darkModeButton = document.querySelector("#toggle-leetrooms-darkmode");
 darkModeButton.addEventListener("click", () => {
     const darkModeState = darkModeButton.checked;
@@ -20,7 +32,7 @@ const settingsContainer = document.querySelector("#leetrooms-settings");
 chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
     const currentUrl = tabs[0].url;
     if (currentUrl.includes("https://leetcode.com")) {
-        settingsContainer.style.display = "block";
+        settingsContainer.style.display = "flex";
         instructionsContainer.style.display = "none";
         chrome.storage.local.get("shouldShowPanel", (result) => {
             const shouldShowPanel = result.shouldShowPanel ?? true;
@@ -39,7 +51,7 @@ chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
         });
     } else {
         settingsContainer.style.display = "none";
-        instructionsContainer.style.display = "block";
+        instructionsContainer.style.display = "flex";
     }
 });
 

--- a/extension/src/public/popup.js
+++ b/extension/src/public/popup.js
@@ -4,6 +4,17 @@ darkModeButton.addEventListener("click", () => {
     chrome.storage.local.set({ leetroomsDarkMode: darkModeState });
 });
 
+const showHideButton = document.querySelector("#show-hide-leetrooms");
+showHideButton.addEventListener("click", () => {
+    const shouldShowPanel = showHideButton.checked;
+    chrome.storage.local.set({ shouldShowPanel: shouldShowPanel });
+    if (shouldShowPanel) {
+        darkModeButton.parentElement.parentElement.style.display = "flex";
+    } else {
+        darkModeButton.parentElement.parentElement.style.display = "none";
+    }
+});
+
 const instructionsContainer = document.querySelector("#leetrooms-instructions");
 const settingsContainer = document.querySelector("#leetrooms-settings");
 chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
@@ -11,6 +22,17 @@ chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
     if (currentUrl.includes("https://leetcode.com")) {
         settingsContainer.style.display = "block";
         instructionsContainer.style.display = "none";
+        chrome.storage.local.get("shouldShowPanel", (result) => {
+            const shouldShowPanel = result.shouldShowPanel ?? true;
+            showHideButton.checked = shouldShowPanel;
+            if (shouldShowPanel) {
+                darkModeButton.parentElement.parentElement.style.display =
+                    "flex";
+            } else {
+                darkModeButton.parentElement.parentElement.style.display =
+                    "none";
+            }
+        });
         chrome.storage.local.get("leetroomsDarkMode", (result) => {
             const darkModeState = result.leetroomsDarkMode ?? true;
             darkModeButton.checked = darkModeState;


### PR DESCRIPTION
- add toggle in the popup html to completely hide/show the LeetRooms panel
- show the extension version at the bottom of the popup html
- clean up some styles in the popup HTML

**BEFORE**:
![Screenshot 2024-04-14 at 1 53 41 AM](https://github.com/marwanhawari/LeetRooms/assets/59078997/d04edc1b-cd35-4f8b-b02a-5c22a56b4afd)
![Screenshot 2024-04-14 at 1 54 04 AM](https://github.com/marwanhawari/LeetRooms/assets/59078997/86993da7-e774-494f-ad20-447a2e9d0d70)


**AFTER**:
![Screenshot 2024-04-14 at 1 54 28 AM](https://github.com/marwanhawari/LeetRooms/assets/59078997/36b32ba5-60a4-4643-8bd1-1ae32920b8b7)
![Screenshot 2024-04-14 at 1 54 45 AM](https://github.com/marwanhawari/LeetRooms/assets/59078997/2d77f9aa-0802-4183-bed0-e03b0ced4721)
