### PR TITLE
fix: show/hide toggle on non-problem pages

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -79,15 +79,15 @@ async function main() {
     }
 
     function showPanel() {
+        chrome.storage.local.get("leetroomsToggleState", (result) => {
+            setToggleState(result.leetroomsToggleState ?? true);
+        });
         chrome.storage.local.set({ shouldShowPanel: true });
-        setToggleState(true);
-        reactRoot.style.display = "block";
         handlebar.style.display = "flex";
     }
 
     function hidePanel() {
         chrome.storage.local.set({ shouldShowPanel: false });
-        setToggleState(false);
         reactRoot.style.display = "none";
         handlebar.style.display = "none";
     }
@@ -174,6 +174,13 @@ async function main() {
     window.addEventListener("mousemove", throttle(updateWidth, 16));
     window.addEventListener("mouseup", stopResizing);
 
+    chrome.storage.local.get("leetroomsToggleState", (result) => {
+        setToggleState(result.leetroomsToggleState ?? true);
+    });
+    chrome.storage.local.get("leetroomsWidth", (result) => {
+        const leetroomsWidth = result.leetroomsWidth ?? "525";
+        reactRoot.style.width = `${leetroomsWidth}px`;
+    });
     chrome.storage.local.get("shouldShowPanel", (result) => {
         const shouldShowPanel = result.shouldShowPanel ?? true;
         if (shouldShowPanel) {
@@ -181,18 +188,6 @@ async function main() {
         } else {
             hidePanel();
         }
-    });
-    chrome.storage.local.get("leetroomsToggleState", (result) => {
-        const toggleState = result.leetroomsToggleState ?? true;
-        if (toggleState) {
-            setToggleState(true);
-        } else {
-            setToggleState(false);
-        }
-    });
-    chrome.storage.local.get("leetroomsWidth", (result) => {
-        const leetroomsWidth = result.leetroomsWidth ?? "525";
-        reactRoot.style.width = `${leetroomsWidth}px`;
     });
 
     const oldUIElement = document.querySelector("#app");

--- a/extension/src/panel.ts
+++ b/extension/src/panel.ts
@@ -47,6 +47,35 @@ async function main() {
         setToggleState(true);
     });
 
+    function showPanel() {
+        chrome.storage.local.get("leetroomsFixedPanelToggleState", (result) => {
+            if (result.leetroomsFixedPanelToggleState === true) {
+                setToggleState(true);
+            } else {
+                setToggleState(false);
+            }
+        });
+        chrome.storage.local.set({ shouldShowPanel: true });
+    }
+
+    function hidePanel() {
+        chrome.storage.local.set({ shouldShowPanel: false });
+        panelContainer.style.display = "none";
+        openPanelTab.style.display = "none";
+    }
+
+    function setToggleState(toggleState: boolean) {
+        if (toggleState) {
+            panelContainer.style.display = "block";
+            openPanelTab.style.display = "none";
+            chrome.storage.local.set({ leetroomsFixedPanelToggleState: true });
+        } else {
+            panelContainer.style.display = "none";
+            openPanelTab.style.display = "flex";
+            chrome.storage.local.set({ leetroomsFixedPanelToggleState: false });
+        }
+    }
+
     chrome.storage.local.get("leetroomsDarkMode", (result) => {
         if (result.leetroomsDarkMode === true) {
             document.body.classList.add("leetrooms-dark");
@@ -63,8 +92,23 @@ async function main() {
         }
     });
 
+    chrome.storage.local.get("shouldShowPanel", (result) => {
+        if (result.shouldShowPanel === true) {
+            showPanel();
+        } else {
+            hidePanel();
+        }
+    });
+
     chrome.storage.onChanged.addListener((changes, namespace) => {
         for (let [key, { oldValue, newValue }] of Object.entries(changes)) {
+            if (key == "shouldShowPanel") {
+                if (newValue == true) {
+                    showPanel();
+                } else {
+                    hidePanel();
+                }
+            }
             if (key == "leetroomsFixedPanelToggleState") {
                 if (newValue == true) {
                     setToggleState(true);
@@ -96,18 +140,6 @@ async function main() {
     openPanelTabText.prepend(openPanelTabChevron);
     openPanelTab.appendChild(openPanelTabText);
     document.body.appendChild(openPanelTab);
-
-    function setToggleState(toggleState: boolean) {
-        if (toggleState) {
-            panelContainer.style.display = "block";
-            openPanelTab.style.display = "none";
-            chrome.storage.local.set({ leetroomsFixedPanelToggleState: true });
-        } else {
-            panelContainer.style.display = "none";
-            openPanelTab.style.display = "flex";
-            chrome.storage.local.set({ leetroomsFixedPanelToggleState: false });
-        }
-    }
 }
 
 main();


### PR DESCRIPTION
Forgot that non-problem pages don't use the content script, so the show/hide toggle in the popup (added in https://github.com/marwanhawari/LeetRooms/pull/63) wasn't working for it. This PR fixes this.

Also fixes show/hide on problem page to read the toggle state from local storage before showing the panel. This makes it so that if the panel was minimized (but not hidden), then when you hide and un-hide, it will still be minimized instead of expanded.